### PR TITLE
Remove UnitTesting dependency

### DIFF
--- a/Rational.quark
+++ b/Rational.quark
@@ -4,7 +4,7 @@
 \version: "1.0.3",
 \schelp: "Rational",
 \url: "https://github.com/smoge/Rational",
-\dependencies: ["UnitTesting"],
+\dependencies: [],
 \copyright: "Bernardo Barros. 2017",
 \license: "GPLv3"
 )

--- a/Tests/TestRacional.sc
+++ b/Tests/TestRacional.sc
@@ -1,4 +1,6 @@
 /*
+	If using SuperCollider <3.9, install UnitTesting quark.
+
 	UnitTest.gui
 	TestRational.run
 	TestRational().numTests_(100000).seed_(999.rand).isVerbose_(true).run;


### PR DESCRIPTION
Hi! This is a small change, but let me know if you think there's another way to solve this issue.

SuperCollider 3.9 (now current, stable version) has merged the UnitTesting quark into its main class library, so that dependency is not needed anymore.  Right now, on SC 3.9, installing Rational is causing a name clash and forcing the user to delete the UnitTesting quark manually.

This PR removes the dependency on the Quark file, and also adds a note at the top of the test case file which instructs user to install UnitTesting quark in case she is using an older version of SuperCollider.